### PR TITLE
support more architectures, move to separate folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,21 @@ Ansible role to configure backups using [autorestic](https://autorestic.vercel.a
 
 None.
 
+## Assumptions
+
+Places versioned executables into `/opt/autorestic/bin` and `/opt/restic/bin` links these into `/usr/local/bin`.
+Any previously installed versions (manually or per package manager) might interfer with this.
+
 ## Role Variables
 
 ```yaml
-autorestic_version: 1.7.3
+autorestic_architecture:
+```
+
+Overrides `ansible_architecture` in case you have some exotic combination. See dependencies.
+
+```yaml
+autorestic_version: 1.7.4
 autorestic_restic_version: 0.14.0
 ```
 
@@ -61,7 +72,22 @@ Whether or not to create an autorestic crontab entry to trigger automated backup
 
 ## Dependencies
 
-None.
+This role depends on precompiled binaries, published on github
+[restic/restic](https://github.com/restic/restic/releases/)
+[cupcakearmy/autorestic](https://github.com/cupcakearmy/autorestic/releases/)
+
+Currently supporte Linux binaries exist for:
+
+  - amd64
+  - arm
+  - arm64
+  - mips
+  - mipsle
+  - mips64
+  - mips64le
+  - ppc64le
+  - s390x
+  - 386
 
 ## Example Playbook
 

--- a/README.md
+++ b/README.md
@@ -13,16 +13,15 @@ None.
 
 ## Assumptions
 
-Places versioned executables into `/opt/autorestic/bin` and `/opt/restic/bin` links these into `/usr/local/bin`.
-Any previously installed versions (manually or per package manager) might interfer with this.
+This role places the autorestic and restic binaries into `/opt/autorestic/bin` and `/opt/restic/bin` respectively. Symbolic links are created to `/usr/local/bin`.
 
 ## Role Variables
 
 ```yaml
-autorestic_architecture:
+autorestic_architecture: mips
 ```
 
-Overrides `ansible_architecture` in case you have some exotic combination. See dependencies.
+Overrides `ansible_architecture` in case you have some exotic combination. See [dependencies](#dependencies) for further details.
 
 ```yaml
 autorestic_version: 1.7.4
@@ -30,6 +29,13 @@ autorestic_restic_version: 0.14.0
 ```
 
 The version of [autorestic](https://autorestic.vercel.app/) and [restic](https://restic.net/) to install.
+
+```yaml
+autorestic_install_directory: /opt/autorestic/bin
+autorestic_restic_install_directory: /opt/restic/bin
+```
+
+The directories to install the autorestic and restic binaries at.
 
 ```yaml
 autorestic_config: |-
@@ -80,22 +86,12 @@ Whether or not to remove autorestic, restic, configuration and crontab entry. Se
 
 ## Dependencies
 
-This role depends on precompiled binaries, published on github
-[restic/restic](https://github.com/restic/restic/releases/)
-[cupcakearmy/autorestic](https://github.com/cupcakearmy/autorestic/releases/)
+This role depends on precompiled binaries published on GitHub:
 
-Currently supporte Linux binaries for:
+* [cupcakearmy/autorestic](https://github.com/cupcakearmy/autorestic/releases/)
+* [restic/restic](https://github.com/restic/restic/releases/)
 
-  - amd64
-  - arm
-  - arm64
-  - mips
-  - mipsle
-  - mips64
-  - mips64le
-  - ppc64le
-  - s390x
-  - 386
+When overriding `ansible_architecture`, refer to the release assets for supported binary architectures.
 
 ## Example Playbook
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,15 @@ autorestic_restic_version: 0.14.0
 The version of [autorestic](https://autorestic.vercel.app/) and [restic](https://restic.net/) to install.
 
 ```yaml
-autorestic_install_directory: /opt/autorestic/bin
-autorestic_restic_install_directory: /opt/restic/bin
+autorestic_install_directory:
+  path: /opt/autorestic/bin
+  # Optional
+  # owner: owner
+  # group: group
+  # mode: 0700
+autorestic_restic_install_directory:
+  path: /opt/restic/bin
+  # ...
 ```
 
 The directories to install the autorestic and restic binaries at.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This role depends on precompiled binaries, published on github
 [restic/restic](https://github.com/restic/restic/releases/)
 [cupcakearmy/autorestic](https://github.com/cupcakearmy/autorestic/releases/)
 
-Currently supporte Linux binaries exist for:
+Currently supporte Linux binaries for:
 
   - amd64
   - arm

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,4 @@ autorestic_check: false
 autorestic_cron: false
 autorestic_install_dir: /opt/autorestic
 autorestic_restic_install_dir: /opt/restic
-autorestic_binary_dir: /usr/local/bin
-autorestic_restic_binary_dir: /usr/local/bin
 autorestic_state: present

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,6 @@ autorestic_config: |-
 autorestic_info: false
 autorestic_check: false
 autorestic_cron: false
-autorestic_install_dir: /opt/autorestic
-autorestic_restic_install_dir: /opt/restic
+autorestic_install_directory: /opt/autorestic/bin
+autorestic_restic_install_directory: /opt/restic/bin
 autorestic_state: present

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,10 @@
 # defaults file for autorestic
 autorestic_version: 1.7.4
 autorestic_restic_version: 0.14.0
-autorestic_install_directory: /opt/autorestic/bin
-autorestic_restic_install_directory: /opt/restic/bin
+autorestic_install_directory:
+  path: /opt/autorestic/bin
+autorestic_restic_install_directory:
+  path: /opt/restic/bin
 autorestic_config: |-
   version: 2
   locations:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 # defaults file for autorestic
 autorestic_version: 1.7.4
 autorestic_restic_version: 0.14.0
+autorestic_install_directory: /opt/autorestic/bin
+autorestic_restic_install_directory: /opt/restic/bin
 autorestic_config: |-
   version: 2
   locations:
@@ -21,6 +23,4 @@ autorestic_config: |-
 autorestic_info: false
 autorestic_check: false
 autorestic_cron: false
-autorestic_install_directory: /opt/autorestic/bin
-autorestic_restic_install_directory: /opt/restic/bin
 autorestic_state: present

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,7 @@ autorestic_config: |-
 autorestic_info: false
 autorestic_check: false
 autorestic_cron: false
+autorestic_install_dir: /opt/autorestic
+autorestic_restic_install_dir: /opt/restic
+autorestic_binary_dir: /usr/local/bin
+autorestic_restic_binary_dir: /usr/local/bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for autorestic
-autorestic_version: 1.7.3
+autorestic_version: 1.7.4
 autorestic_restic_version: 0.14.0
 autorestic_config: |-
   version: 2

--- a/tasks/autorestic.yml
+++ b/tasks/autorestic.yml
@@ -1,11 +1,17 @@
 ---
 # autorestic tasks file for autorestic
+- name: Ensure autorestic directory exist
+  ansible.builtin.file:
+    state: directory
+    path: /opt/autorestic/bin
+    mode: 0755
+    owner: root
+
 - name: "Download autorestic binary v{{ autorestic_version }} for aarch64"
   # E.g., Raspberry Pi 4
   ansible.builtin.get_url:
     url: "https://github.com/cupcakearmy/autorestic/releases/download/v{{ autorestic_version }}/autorestic_{{ autorestic_version }}_linux_arm64.bz2" # noqa yaml[line-length]
     dest: /tmp/autorestic.bz2
-    mode: 0755
   when: ansible_architecture == "aarch64"
 
 - name: "Download autorestic binary v{{ autorestic_version }} for armv7l"
@@ -13,22 +19,43 @@
   ansible.builtin.get_url:
     url: "https://github.com/cupcakearmy/autorestic/releases/download/v{{ autorestic_version }}/autorestic_{{ autorestic_version }}_linux_arm.bz2"
     dest: /tmp/autorestic.bz2
-    mode: 0755
   when: ansible_architecture == "armv7l"
 
 - name: "Download autorestic binary v{{ autorestic_version }} for x86_64"
   ansible.builtin.get_url:
     url: "https://github.com/cupcakearmy/autorestic/releases/download/v{{ autorestic_version }}/autorestic_{{ autorestic_version }}_linux_amd64.bz2" # noqa yaml[line-length]
     dest: /tmp/autorestic.bz2
-    mode: 0755
   when: ansible_architecture == "x86_64"
 
-- name: Extract and install autorestic # noqa no-changed-when
+- name: "Download autorestic binary v{{ autorestic_version }} for other architectures"
+  # Generic list containing available linux builds
+  ansible.builtin.get_url:
+    url: "https://github.com/cupcakearmy/autorestic/releases/download/v{{ autorestic_version }}/autorestic_{{ autorestic_version }}_linux_{{ item }}.bz2"
+    dest: /tmp/autorestic.bz2
+  when: ansible_architecture == item
+  with_items:
+    - mips
+    - mipsle
+    - mips64
+    - mips64le
+    - ppc64le
+    - s390x
+    - 386
+
+- name: Extract and install autorestic
   ansible.builtin.shell:
-    cmd: cd /tmp/ && bzip2 -f -d /tmp/autorestic.bz2 && mv /tmp/autorestic /usr/local/bin/
+    cmd: cd /tmp/ && bzip2 -f -d /tmp/autorestic.bz2 && mv /tmp/autorestic /opt/autorestic/bin/autorestic-{{ autorestic_version }}
+    creates: /opt/autorestic/bin/autorestic-{{ autorestic_version }}
   become: true
 
 - name: Ensure autorestic is executable
   ansible.builtin.file:
-    path: /usr/local/bin/autorestic
+    path: /opt/autorestic/bin/autorestic-{{ autorestic_version }}
     mode: +x
+
+- name: Create symbolic link to the correct version
+  file:
+    src: /opt/autorestic/bin/autorestic-{{ autorestic_version }}
+    path: /usr/local/bin/autorestic
+    state: link
+    force: true

--- a/tasks/autorestic.yml
+++ b/tasks/autorestic.yml
@@ -1,6 +1,6 @@
 ---
 # autorestic tasks file for autorestic
-- name: Ensure autorestic directory exist
+- name: Ensure autorestic install directory exists
   ansible.builtin.file:
     state: directory
     path: "{{ autorestic_install_directory }}"

--- a/tasks/autorestic.yml
+++ b/tasks/autorestic.yml
@@ -3,7 +3,7 @@
 - name: Ensure autorestic directory exist
   ansible.builtin.file:
     state: directory
-    path: "{{ autorestic_install_dir }}/bin"
+    path: "{{ autorestic_install_directory }}"
     mode: 0755
     owner: root
 
@@ -52,18 +52,18 @@
 
 - name: Extract and install autorestic
   ansible.builtin.shell:
-    cmd: cd /tmp/ && bzip2 -f -d /tmp/autorestic.bz2 && mv /tmp/autorestic {{ autorestic_install_dir }}/autorestic-{{ autorestic_version }}
-    creates: "{{ autorestic_install_dir }}/autorestic-{{ autorestic_version }}"
+    cmd: cd /tmp/ && bzip2 -f -d /tmp/autorestic.bz2 && mv /tmp/autorestic {{ autorestic_install_directory }}/autorestic-{{ autorestic_version }}
+    creates: "{{ autorestic_install_directory }}/autorestic-{{ autorestic_version }}"
   become: true
 
 - name: Ensure autorestic is executable
   ansible.builtin.file:
-    path: "{{ autorestic_install_dir }}/autorestic-{{ autorestic_version }}"
+    path: "{{ autorestic_install_directory }}/autorestic-{{ autorestic_version }}"
     mode: +x
 
 - name: Create symbolic link to the correct version
   ansible.builtin.file:
-    src: "{{ autorestic_install_dir }}/autorestic-{{ autorestic_version }}"
+    src: "{{ autorestic_install_directory }}/autorestic-{{ autorestic_version }}"
     path: /usr/local/bin/autorestic
     state: link
     force: true

--- a/tasks/autorestic.yml
+++ b/tasks/autorestic.yml
@@ -7,7 +7,7 @@
     mode: 0755
     owner: root
 
-- name: "Download autorestic binary v{{ autorestic_version }} for aarch64"
+- name: "Download autorestic binary for aarch64 v{{ autorestic_version }}"
   # E.g., Raspberry Pi 4
   ansible.builtin.get_url:
     url: "https://github.com/cupcakearmy/autorestic/releases/download/v{{ autorestic_version }}/autorestic_{{ autorestic_version }}_linux_arm64.bz2" # noqa yaml[line-length]
@@ -16,7 +16,7 @@
     owner: root
   when: ansible_architecture == "aarch64"
 
-- name: "Download autorestic binary v{{ autorestic_version }} for armv7l"
+- name: "Download autorestic binary for armv7l v{{ autorestic_version }}"
   # E.g., Raspberry Pi 3 (32bit)
   ansible.builtin.get_url:
     url: "https://github.com/cupcakearmy/autorestic/releases/download/v{{ autorestic_version }}/autorestic_{{ autorestic_version }}_linux_arm.bz2"
@@ -25,7 +25,7 @@
     owner: root
   when: ansible_architecture == "armv7l"
 
-- name: "Download autorestic binary v{{ autorestic_version }} for x86_64"
+- name: "Download autorestic binary for x86_64 v{{ autorestic_version }}"
   ansible.builtin.get_url:
     url: "https://github.com/cupcakearmy/autorestic/releases/download/v{{ autorestic_version }}/autorestic_{{ autorestic_version }}_linux_amd64.bz2" # noqa yaml[line-length]
     dest: /tmp/autorestic.bz2
@@ -33,7 +33,7 @@
     owner: root
   when: ansible_architecture == "x86_64"
 
-- name: "Download autorestic binary v{{ autorestic_version }} for other architectures"
+- name: "Download autorestic binary for other architectures v{{ autorestic_version }}"
   # Generic list containing available linux builds
   ansible.builtin.get_url:
     url: "https://github.com/cupcakearmy/autorestic/releases/download/v{{ autorestic_version }}/autorestic_{{ autorestic_version }}_linux_{{ item }}.bz2"
@@ -52,18 +52,18 @@
 
 - name: Extract and install autorestic
   ansible.builtin.shell:
-    cmd: cd /tmp/ && bzip2 -f -d /tmp/autorestic.bz2 && mv /tmp/autorestic {{ autorestic_install_dir}}/autorestic-{{ autorestic_version }}
-    creates: "{{ autorestic_install_dir}}/bin/autorestic-{{ autorestic_version }}"
+    cmd: cd /tmp/ && bzip2 -f -d /tmp/autorestic.bz2 && mv /tmp/autorestic {{ autorestic_install_dir }}/autorestic-{{ autorestic_version }}
+    creates: "{{ autorestic_install_dir }}/bin/autorestic-{{ autorestic_version }}"
   become: true
 
 - name: Ensure autorestic is executable
   ansible.builtin.file:
-    path: "{{ autorestic_install_dir}}/bin/autorestic-{{ autorestic_version }}"
+    path: "{{ autorestic_install_dir }}/bin/autorestic-{{ autorestic_version }}"
     mode: +x
 
 - name: Create symbolic link to the correct version
   ansible.builtin.file:
-    src: "{{ autorestic_install_dir}}/bin/autorestic-{{ autorestic_version }}"
+    src: "{{ autorestic_install_dir }}/bin/autorestic-{{ autorestic_version }}"
     path: "{{ autorestic_binary_dir }}/autorestic"
     state: link
     force: true

--- a/tasks/autorestic.yml
+++ b/tasks/autorestic.yml
@@ -64,6 +64,6 @@
 - name: Create symbolic link to the correct version
   ansible.builtin.file:
     src: "{{ autorestic_install_dir }}/autorestic-{{ autorestic_version }}"
-    path: "{{ autorestic_binary_dir }}/autorestic"
+    path: /usr/local/bin/autorestic
     state: link
     force: true

--- a/tasks/autorestic.yml
+++ b/tasks/autorestic.yml
@@ -12,6 +12,8 @@
   ansible.builtin.get_url:
     url: "https://github.com/cupcakearmy/autorestic/releases/download/v{{ autorestic_version }}/autorestic_{{ autorestic_version }}_linux_arm64.bz2" # noqa yaml[line-length]
     dest: /tmp/autorestic.bz2
+    mode: 0644
+    owner: root
   when: ansible_architecture == "aarch64"
 
 - name: "Download autorestic binary v{{ autorestic_version }} for armv7l"
@@ -19,12 +21,16 @@
   ansible.builtin.get_url:
     url: "https://github.com/cupcakearmy/autorestic/releases/download/v{{ autorestic_version }}/autorestic_{{ autorestic_version }}_linux_arm.bz2"
     dest: /tmp/autorestic.bz2
+    mode: 0644
+    owner: root
   when: ansible_architecture == "armv7l"
 
 - name: "Download autorestic binary v{{ autorestic_version }} for x86_64"
   ansible.builtin.get_url:
     url: "https://github.com/cupcakearmy/autorestic/releases/download/v{{ autorestic_version }}/autorestic_{{ autorestic_version }}_linux_amd64.bz2" # noqa yaml[line-length]
     dest: /tmp/autorestic.bz2
+    mode: 0644
+    owner: root
   when: ansible_architecture == "x86_64"
 
 - name: "Download autorestic binary v{{ autorestic_version }} for other architectures"
@@ -32,6 +38,8 @@
   ansible.builtin.get_url:
     url: "https://github.com/cupcakearmy/autorestic/releases/download/v{{ autorestic_version }}/autorestic_{{ autorestic_version }}_linux_{{ item }}.bz2"
     dest: /tmp/autorestic.bz2
+    mode: 0644
+    owner: root
   when: ansible_architecture == item
   with_items:
     - mips
@@ -54,7 +62,7 @@
     mode: +x
 
 - name: Create symbolic link to the correct version
-  file:
+  ansible.builtin.file:
     src: /opt/autorestic/bin/autorestic-{{ autorestic_version }}
     path: /usr/local/bin/autorestic
     state: link

--- a/tasks/autorestic.yml
+++ b/tasks/autorestic.yml
@@ -2,10 +2,11 @@
 # autorestic tasks file for autorestic
 - name: Ensure autorestic install directory exists
   ansible.builtin.file:
+    path: "{{ autorestic_install_directory.path }}"
     state: directory
-    path: "{{ autorestic_install_directory }}"
-    mode: 0755
-    owner: root
+    owner: "{{ autorestic_install_directory.owner | default(omit) }}"
+    group: "{{ autorestic_install_directory.group | default(omit) }}"
+    mode: "{{ autorestic_install_directory.mode | default('0755') }}"
 
 - name: "Download autorestic binary for aarch64 v{{ autorestic_version }}"
   # E.g., Raspberry Pi 4
@@ -13,7 +14,6 @@
     url: "https://github.com/cupcakearmy/autorestic/releases/download/v{{ autorestic_version }}/autorestic_{{ autorestic_version }}_linux_arm64.bz2" # noqa yaml[line-length]
     dest: /tmp/autorestic.bz2
     mode: 0644
-    owner: root
   when: ansible_architecture == "aarch64"
 
 - name: "Download autorestic binary for armv7l v{{ autorestic_version }}"
@@ -22,7 +22,6 @@
     url: "https://github.com/cupcakearmy/autorestic/releases/download/v{{ autorestic_version }}/autorestic_{{ autorestic_version }}_linux_arm.bz2"
     dest: /tmp/autorestic.bz2
     mode: 0644
-    owner: root
   when: ansible_architecture == "armv7l"
 
 - name: "Download autorestic binary for x86_64 v{{ autorestic_version }}"
@@ -30,7 +29,6 @@
     url: "https://github.com/cupcakearmy/autorestic/releases/download/v{{ autorestic_version }}/autorestic_{{ autorestic_version }}_linux_amd64.bz2" # noqa yaml[line-length]
     dest: /tmp/autorestic.bz2
     mode: 0644
-    owner: root
   when: ansible_architecture == "x86_64"
 
 - name: "Download autorestic binary for other architectures v{{ autorestic_version }}"
@@ -39,7 +37,6 @@
     url: "https://github.com/cupcakearmy/autorestic/releases/download/v{{ autorestic_version }}/autorestic_{{ autorestic_version }}_linux_{{ item }}.bz2"
     dest: /tmp/autorestic.bz2
     mode: 0644
-    owner: root
   when: ansible_architecture == item
   with_items:
     - mips
@@ -52,18 +49,18 @@
 
 - name: Extract and install autorestic
   ansible.builtin.shell:
-    cmd: cd /tmp/ && bzip2 -f -d /tmp/autorestic.bz2 && mv /tmp/autorestic {{ autorestic_install_directory }}/autorestic-{{ autorestic_version }}
-    creates: "{{ autorestic_install_directory }}/autorestic-{{ autorestic_version }}"
+    cmd: cd /tmp/ && bzip2 -f -d /tmp/autorestic.bz2 && mv /tmp/autorestic {{ autorestic_install_directory.path }}/autorestic-{{ autorestic_version }}
+    creates: "{{ autorestic_install_directory.path }}/autorestic-{{ autorestic_version }}"
   become: true
 
 - name: Ensure autorestic is executable
   ansible.builtin.file:
-    path: "{{ autorestic_install_directory }}/autorestic-{{ autorestic_version }}"
+    path: "{{ autorestic_install_directory.path }}/autorestic-{{ autorestic_version }}"
     mode: +x
 
 - name: Create symbolic link to the correct version
   ansible.builtin.file:
-    src: "{{ autorestic_install_directory }}/autorestic-{{ autorestic_version }}"
+    src: "{{ autorestic_install_directory.path }}/autorestic-{{ autorestic_version }}"
     path: /usr/local/bin/autorestic
     state: link
     force: true

--- a/tasks/autorestic.yml
+++ b/tasks/autorestic.yml
@@ -53,17 +53,17 @@
 - name: Extract and install autorestic
   ansible.builtin.shell:
     cmd: cd /tmp/ && bzip2 -f -d /tmp/autorestic.bz2 && mv /tmp/autorestic {{ autorestic_install_dir }}/autorestic-{{ autorestic_version }}
-    creates: "{{ autorestic_install_dir }}/bin/autorestic-{{ autorestic_version }}"
+    creates: "{{ autorestic_install_dir }}/autorestic-{{ autorestic_version }}"
   become: true
 
 - name: Ensure autorestic is executable
   ansible.builtin.file:
-    path: "{{ autorestic_install_dir }}/bin/autorestic-{{ autorestic_version }}"
+    path: "{{ autorestic_install_dir }}/autorestic-{{ autorestic_version }}"
     mode: +x
 
 - name: Create symbolic link to the correct version
   ansible.builtin.file:
-    src: "{{ autorestic_install_dir }}/bin/autorestic-{{ autorestic_version }}"
+    src: "{{ autorestic_install_dir }}/autorestic-{{ autorestic_version }}"
     path: "{{ autorestic_binary_dir }}/autorestic"
     state: link
     force: true

--- a/tasks/autorestic.yml
+++ b/tasks/autorestic.yml
@@ -3,7 +3,7 @@
 - name: Ensure autorestic directory exist
   ansible.builtin.file:
     state: directory
-    path: /opt/autorestic/bin
+    path: "{{ autorestic_install_dir }}/bin"
     mode: 0755
     owner: root
 
@@ -52,18 +52,18 @@
 
 - name: Extract and install autorestic
   ansible.builtin.shell:
-    cmd: cd /tmp/ && bzip2 -f -d /tmp/autorestic.bz2 && mv /tmp/autorestic /opt/autorestic/bin/autorestic-{{ autorestic_version }}
-    creates: /opt/autorestic/bin/autorestic-{{ autorestic_version }}
+    cmd: cd /tmp/ && bzip2 -f -d /tmp/autorestic.bz2 && mv /tmp/autorestic {{ autorestic_install_dir}}/autorestic-{{ autorestic_version }}
+    creates: "{{ autorestic_install_dir}}/bin/autorestic-{{ autorestic_version }}"
   become: true
 
 - name: Ensure autorestic is executable
   ansible.builtin.file:
-    path: /opt/autorestic/bin/autorestic-{{ autorestic_version }}
+    path: "{{ autorestic_install_dir}}/bin/autorestic-{{ autorestic_version }}"
     mode: +x
 
 - name: Create symbolic link to the correct version
   ansible.builtin.file:
-    src: /opt/autorestic/bin/autorestic-{{ autorestic_version }}
-    path: /usr/local/bin/autorestic
+    src: "{{ autorestic_install_dir}}/bin/autorestic-{{ autorestic_version }}"
+    path: "{{ autorestic_binary_dir }}/autorestic"
     state: link
     force: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Override ansible_architecture
   ansible.builtin.set_fact:
     ansible_architecture: "{{ autorestic_architecture }}"
-    when: autorestic_architecture is defined
+  when: autorestic_architecture is defined
 
 - name: Install bzip2
   ansible.builtin.package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,11 +7,11 @@
 
 - name: Import removal tasks
   ansible.builtin.import_tasks: removal.yml
-  when: autorestic_state is "absent"
+  when: autorestic_state == "absent"
 
 - name: End play when autorestic_state is absent
   ansible.builtin.meta: end_host
-  when: autorestic_state is "absent"
+  when: autorestic_state == "absent"
 
 - name: Install bzip2
   ansible.builtin.package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 # tasks file for autorestic
+- name: Override ansible_architecture
+  ansible.builtin.set_fact:
+    ansible_architecture: "{{ autorestic_architecture }}"
+    when: autorestic_architecture is defined
+
 - name: Install bzip2
   ansible.builtin.package:
     name: bzip2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,10 @@
   ansible.builtin.import_tasks: autorestic.yml
   when: autorestic_install_status.rc != 0 or not autorestic_install_status.stdout is search(autorestic_version)
 
+- name: Get facts to reset ansible_architecture
+  ansible.builtin.setup:
+  when: autorestic_architecture is defined
+
 - name: Create autorestic configuration file
   ansible.builtin.copy:
     content: "{{ autorestic_config }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,11 +7,11 @@
 
 - name: Import removal tasks
   ansible.builtin.import_tasks: removal.yml
-  when: autorestic_state == 'absent'
+  when: autorestic_state is "absent"
 
 - name: End play when autorestic_state is absent
   ansible.builtin.meta: end_host
-  when: autorestic_state == 'absent'
+  when: autorestic_state is "absent"
 
 - name: Install bzip2
   ansible.builtin.package:

--- a/tasks/removal.yml
+++ b/tasks/removal.yml
@@ -2,8 +2,11 @@
 # removal tasks file for autorestic
 - name: Remove autorestic binary
   ansible.builtin.file:
-    path: /usr/local/bin/autorestic
+    path: "{{ item }}"
     state: absent
+  with_items:
+    - "{{ autorestic_install_directory.path }}"
+    - /usr/local/bin/autorestic
   become: true
 
 - name: Remove autorestic configuration file
@@ -13,8 +16,11 @@
 
 - name: Remove restic binary
   ansible.builtin.file:
-    path: /usr/local/bin/restic
+    path: "{{ item }}"
     state: absent
+  with_items:
+    - "{{ autorestic_restic_install_directory.path }}"
+    - /usr/local/bin/restic
   become: true
 
 - name: Remove autorestic crontab

--- a/tasks/restic.yml
+++ b/tasks/restic.yml
@@ -7,7 +7,7 @@
     mode: 0755
     owner: root
 
-- name: "Download restic binary v{{ autorestic_restic_version }} for aarch64"
+- name: "Download restic binary for aarch64 v{{ autorestic_restic_version }}"
   # E.g., Raspberry Pi 4
   ansible.builtin.get_url:
     url: "https://github.com/restic/restic/releases/download/v{{ autorestic_restic_version }}/restic_{{ autorestic_restic_version }}_linux_arm64.bz2"
@@ -16,7 +16,7 @@
     owner: root
   when: ansible_architecture == "aarch64"
 
-- name: "Download restic binary v{{ autorestic_restic_version }} for armv7l"
+- name: "Download restic binary for armv7l v{{ autorestic_restic_version }}"
   # E.g., Raspberry Pi 3 (32bit)
   ansible.builtin.get_url:
     url: "https://github.com/restic/restic/releases/download/v{{ autorestic_restic_version }}/restic_{{ autorestic_restic_version }}_linux_arm.bz2"
@@ -25,7 +25,7 @@
     owner: root
   when: ansible_architecture == "armv7l"
 
-- name: "Download restic binary v{{ autorestic_restic_version }} for x86_64"
+- name: "Download restic binary for x86_64 v{{ autorestic_restic_version }}"
   ansible.builtin.get_url:
     url: "https://github.com/restic/restic/releases/download/v{{ autorestic_restic_version }}/restic_{{ autorestic_restic_version }}_linux_amd64.bz2"
     dest: /tmp/restic.bz2
@@ -33,7 +33,7 @@
     owner: root
   when: ansible_architecture == "x86_64"
 
-- name: "Download restic binary v{{ autorestic_restic_version }} for other architectures "
+- name: "Download restic binary for other architectures v{{ autorestic_restic_version }}"
   # Generic list containing available linux builds
   ansible.builtin.get_url:
     url: "https://github.com/restic/restic/releases/download/v{{ autorestic_restic_version }}/restic_{{ autorestic_restic_version }}_linux_{{ item }}.bz2"

--- a/tasks/restic.yml
+++ b/tasks/restic.yml
@@ -12,6 +12,8 @@
   ansible.builtin.get_url:
     url: "https://github.com/restic/restic/releases/download/v{{ autorestic_restic_version }}/restic_{{ autorestic_restic_version }}_linux_arm64.bz2"
     dest: /tmp/restic.bz2
+    mode: 0644
+    owner: root
   when: ansible_architecture == "aarch64"
 
 - name: "Download restic binary v{{ autorestic_restic_version }} for armv7l"
@@ -19,12 +21,16 @@
   ansible.builtin.get_url:
     url: "https://github.com/restic/restic/releases/download/v{{ autorestic_restic_version }}/restic_{{ autorestic_restic_version }}_linux_arm.bz2"
     dest: /tmp/restic.bz2
+    mode: 0644
+    owner: root
   when: ansible_architecture == "armv7l"
 
 - name: "Download restic binary v{{ autorestic_restic_version }} for x86_64"
   ansible.builtin.get_url:
     url: "https://github.com/restic/restic/releases/download/v{{ autorestic_restic_version }}/restic_{{ autorestic_restic_version }}_linux_amd64.bz2"
     dest: /tmp/restic.bz2
+    mode: 0644
+    owner: root
   when: ansible_architecture == "x86_64"
 
 - name: "Download restic binary v{{ autorestic_restic_version }} for other architectures "
@@ -32,6 +38,8 @@
   ansible.builtin.get_url:
     url: "https://github.com/restic/restic/releases/download/v{{ autorestic_restic_version }}/restic_{{ autorestic_restic_version }}_linux_{{ item }}.bz2"
     dest: /tmp/restic.bz2
+    mode: 0644
+    owner: root
   when: ansible_architecture == item
   with_items:
     - mips

--- a/tasks/restic.yml
+++ b/tasks/restic.yml
@@ -1,6 +1,6 @@
 ---
 # restic tasks file for autorestic
-- name: Ensure restic directory exist
+- name: Ensure restic install directory exists
   ansible.builtin.file:
     state: directory
     path: "{{ autorestic_restic_install_directory }}"

--- a/tasks/restic.yml
+++ b/tasks/restic.yml
@@ -3,7 +3,7 @@
 - name: Ensure restic directory exist
   ansible.builtin.file:
     state: directory
-    path: "{{ autorestic_restic_install_dir }}/bin"
+    path: "{{ autorestic_restic_install_directory }}"
     mode: 0755
     owner: root
 
@@ -52,18 +52,18 @@
 
 - name: Extract and install restic
   ansible.builtin.shell:
-    cmd: cd /tmp/ && bzip2 -f -d /tmp/restic.bz2 && mv /tmp/restic {{ autorestic_restic_install_dir }}/restic-{{ autorestic_restic_version }}
-    creates: "{{ autorestic_restic_install_dir }}/restic-{{ autorestic_restic_version }}"
+    cmd: cd /tmp/ && bzip2 -f -d /tmp/restic.bz2 && mv /tmp/restic {{ autorestic_restic_install_directory }}/restic-{{ autorestic_restic_version }}
+    creates: "{{ autorestic_restic_install_directory }}/restic-{{ autorestic_restic_version }}"
   become: true
 
 - name: Ensure restic is executable
   ansible.builtin.file:
-    path: "{{ autorestic_restic_install_dir }}/restic-{{ autorestic_restic_version }}"
+    path: "{{ autorestic_restic_install_directory }}/restic-{{ autorestic_restic_version }}"
     mode: +x
 
 - name: Create symbolic link to the correct version
   ansible.builtin.file:
-    src: "{{ autorestic_restic_install_dir }}/restic-{{ autorestic_restic_version }}"
+    src: "{{ autorestic_restic_install_directory }}/restic-{{ autorestic_restic_version }}"
     path: /usr/local/bin/restic
     state: link
     force: true

--- a/tasks/restic.yml
+++ b/tasks/restic.yml
@@ -2,10 +2,12 @@
 # restic tasks file for autorestic
 - name: Ensure restic install directory exists
   ansible.builtin.file:
+    path: "{{ autorestic_restic_install_directory.path }}"
     state: directory
-    path: "{{ autorestic_restic_install_directory }}"
-    mode: 0755
-    owner: root
+    owner: "{{ autorestic_restic_install_directory.owner | default(omit) }}"
+    group: "{{ autorestic_restic_install_directory.group | default(omit) }}"
+    mode: "{{ autorestic_restic_install_directory.mode | default('0755') }}"
+
 
 - name: "Download restic binary for aarch64 v{{ autorestic_restic_version }}"
   # E.g., Raspberry Pi 4
@@ -13,7 +15,6 @@
     url: "https://github.com/restic/restic/releases/download/v{{ autorestic_restic_version }}/restic_{{ autorestic_restic_version }}_linux_arm64.bz2"
     dest: /tmp/restic.bz2
     mode: 0644
-    owner: root
   when: ansible_architecture == "aarch64"
 
 - name: "Download restic binary for armv7l v{{ autorestic_restic_version }}"
@@ -22,7 +23,6 @@
     url: "https://github.com/restic/restic/releases/download/v{{ autorestic_restic_version }}/restic_{{ autorestic_restic_version }}_linux_arm.bz2"
     dest: /tmp/restic.bz2
     mode: 0644
-    owner: root
   when: ansible_architecture == "armv7l"
 
 - name: "Download restic binary for x86_64 v{{ autorestic_restic_version }}"
@@ -30,7 +30,6 @@
     url: "https://github.com/restic/restic/releases/download/v{{ autorestic_restic_version }}/restic_{{ autorestic_restic_version }}_linux_amd64.bz2"
     dest: /tmp/restic.bz2
     mode: 0644
-    owner: root
   when: ansible_architecture == "x86_64"
 
 - name: "Download restic binary for other architectures v{{ autorestic_restic_version }}"
@@ -39,7 +38,6 @@
     url: "https://github.com/restic/restic/releases/download/v{{ autorestic_restic_version }}/restic_{{ autorestic_restic_version }}_linux_{{ item }}.bz2"
     dest: /tmp/restic.bz2
     mode: 0644
-    owner: root
   when: ansible_architecture == item
   with_items:
     - mips
@@ -52,18 +50,18 @@
 
 - name: Extract and install restic
   ansible.builtin.shell:
-    cmd: cd /tmp/ && bzip2 -f -d /tmp/restic.bz2 && mv /tmp/restic {{ autorestic_restic_install_directory }}/restic-{{ autorestic_restic_version }}
-    creates: "{{ autorestic_restic_install_directory }}/restic-{{ autorestic_restic_version }}"
+    cmd: cd /tmp/ && bzip2 -f -d /tmp/restic.bz2 && mv /tmp/restic {{ autorestic_restic_install_directory.path }}/restic-{{ autorestic_restic_version }}
+    creates: "{{ autorestic_restic_install_directory.path }}/restic-{{ autorestic_restic_version }}"
   become: true
 
 - name: Ensure restic is executable
   ansible.builtin.file:
-    path: "{{ autorestic_restic_install_directory }}/restic-{{ autorestic_restic_version }}"
+    path: "{{ autorestic_restic_install_directory.path }}/restic-{{ autorestic_restic_version }}"
     mode: +x
 
 - name: Create symbolic link to the correct version
   ansible.builtin.file:
-    src: "{{ autorestic_restic_install_directory }}/restic-{{ autorestic_restic_version }}"
+    src: "{{ autorestic_restic_install_directory.path }}/restic-{{ autorestic_restic_version }}"
     path: /usr/local/bin/restic
     state: link
     force: true

--- a/tasks/restic.yml
+++ b/tasks/restic.yml
@@ -64,6 +64,6 @@
 - name: Create symbolic link to the correct version
   ansible.builtin.file:
     src: "{{ autorestic_restic_install_dir }}/restic-{{ autorestic_restic_version }}"
-    path: "{{ autorestic_restic_binary_dir }}/restic"
+    path: /usr/local/bin/restic
     state: link
     force: true

--- a/tasks/restic.yml
+++ b/tasks/restic.yml
@@ -52,18 +52,18 @@
 
 - name: Extract and install restic
   ansible.builtin.shell:
-    cmd: cd /tmp/ && bzip2 -f -d /tmp/restic.bz2 && mv /tmp/restic {{ autorestic_restic_install_dir }}/bin/restic-{{ autorestic_restic_version }}
-    creates: "{{ autorestic_restic_install_dir }}/bin/restic-{{ autorestic_restic_version }}"
+    cmd: cd /tmp/ && bzip2 -f -d /tmp/restic.bz2 && mv /tmp/restic {{ autorestic_restic_install_dir }}/restic-{{ autorestic_restic_version }}
+    creates: "{{ autorestic_restic_install_dir }}/restic-{{ autorestic_restic_version }}"
   become: true
 
 - name: Ensure restic is executable
   ansible.builtin.file:
-    path: "{{ autorestic_restic_install_dir }}/bin/restic-{{ autorestic_restic_version }}"
+    path: "{{ autorestic_restic_install_dir }}/restic-{{ autorestic_restic_version }}"
     mode: +x
 
 - name: Create symbolic link to the correct version
   ansible.builtin.file:
-    src: "{{ autorestic_restic_install_dir }}/bin/restic-{{ autorestic_restic_version }}"
+    src: "{{ autorestic_restic_install_dir }}/restic-{{ autorestic_restic_version }}"
     path: "{{ autorestic_restic_binary_dir }}/restic"
     state: link
     force: true

--- a/tasks/restic.yml
+++ b/tasks/restic.yml
@@ -3,7 +3,7 @@
 - name: Ensure restic directory exist
   ansible.builtin.file:
     state: directory
-    path: /opt/restic/bin
+    path: "{{ autorestic_restic_install_dir }}/bin"
     mode: 0755
     owner: root
 
@@ -52,18 +52,18 @@
 
 - name: Extract and install restic
   ansible.builtin.shell:
-    cmd: cd /tmp/ && bzip2 -f -d /tmp/restic.bz2 && mv /tmp/restic /opt/restic/bin/restic-{{ autorestic_restic_version }}
-    creates: /opt/restic/bin/restic-{{ autorestic_restic_version }}
+    cmd: cd /tmp/ && bzip2 -f -d /tmp/restic.bz2 && mv /tmp/restic {{ autorestic_restic_install_dir }}/bin/restic-{{ autorestic_restic_version }}
+    creates: "{{ autorestic_restic_install_dir }}/bin/restic-{{ autorestic_restic_version }}"
   become: true
 
 - name: Ensure restic is executable
   ansible.builtin.file:
-    path: "/opt/restic/bin/restic-{{ autorestic_restic_version }}"
+    path: "{{ autorestic_restic_install_dir }}/bin/restic-{{ autorestic_restic_version }}"
     mode: +x
 
 - name: Create symbolic link to the correct version
   ansible.builtin.file:
-    src: /opt/restic/bin/restic-{{ autorestic_restic_version }}
-    path: /usr/local/bin/restic
+    src: "{{ autorestic_restic_install_dir }}/bin/restic-{{ autorestic_restic_version }}"
+    path: "{{ autorestic_restic_binary_dir }}/restic"
     state: link
     force: true

--- a/tasks/restic.yml
+++ b/tasks/restic.yml
@@ -1,11 +1,17 @@
 ---
 # restic tasks file for autorestic
+- name: Ensure restic directory exist
+  ansible.builtin.file:
+    state: directory
+    path: /opt/restic/bin
+    mode: 0755
+    owner: root
+
 - name: "Download restic binary v{{ autorestic_restic_version }} for aarch64"
   # E.g., Raspberry Pi 4
   ansible.builtin.get_url:
     url: "https://github.com/restic/restic/releases/download/v{{ autorestic_restic_version }}/restic_{{ autorestic_restic_version }}_linux_arm64.bz2"
     dest: /tmp/restic.bz2
-    mode: 0755
   when: ansible_architecture == "aarch64"
 
 - name: "Download restic binary v{{ autorestic_restic_version }} for armv7l"
@@ -13,22 +19,43 @@
   ansible.builtin.get_url:
     url: "https://github.com/restic/restic/releases/download/v{{ autorestic_restic_version }}/restic_{{ autorestic_restic_version }}_linux_arm.bz2"
     dest: /tmp/restic.bz2
-    mode: 0755
   when: ansible_architecture == "armv7l"
 
 - name: "Download restic binary v{{ autorestic_restic_version }} for x86_64"
   ansible.builtin.get_url:
     url: "https://github.com/restic/restic/releases/download/v{{ autorestic_restic_version }}/restic_{{ autorestic_restic_version }}_linux_amd64.bz2"
     dest: /tmp/restic.bz2
-    mode: 0755
   when: ansible_architecture == "x86_64"
 
-- name: Extract and install restic # noqa no-changed-when
+- name: "Download restic binary v{{ autorestic_restic_version }} for other architectures "
+  # Generic list containing available linux builds
+  ansible.builtin.get_url:
+    url: "https://github.com/restic/restic/releases/download/v{{ autorestic_restic_version }}/restic_{{ autorestic_restic_version }}_linux_{{ item }}.bz2"
+    dest: /tmp/restic.bz2
+  when: ansible_architecture == item
+  with_items:
+    - mips
+    - mipsle
+    - mips64
+    - mips64le
+    - ppc64le
+    - s390x
+    - 386
+
+- name: Extract and install restic
   ansible.builtin.shell:
-    cmd: cd /tmp/ && bzip2 -f -d /tmp/restic.bz2 && mv /tmp/restic /usr/local/bin/
+    cmd: cd /tmp/ && bzip2 -f -d /tmp/restic.bz2 && mv /tmp/restic /opt/restic/bin/restic-{{ autorestic_restic_version }}
+    creates: /opt/restic/bin/restic-{{ autorestic_restic_version }}
   become: true
 
 - name: Ensure restic is executable
   ansible.builtin.file:
-    path: /usr/local/bin/restic
+    path: "/opt/restic/bin/restic-{{ autorestic_restic_version }}"
     mode: +x
+
+- name: Create symbolic link to the correct version
+  ansible.builtin.file:
+    src: /opt/restic/bin/restic-{{ autorestic_restic_version }}
+    path: /usr/local/bin/restic
+    state: link
+    force: true


### PR DESCRIPTION
and another one. this one might be a bit tricky, as it introduces filesystem changes, like described under Assumptions in the readme.

i'm leaving versioned binaries under /opt/ and link the version defined in the playbook into `/usr/local/bin` which i believe is the canonical location for binaries installed like this. 

in a way, it's a breaking change, cause the role now does not care about preexisting installations of either restic or autorestic under `/usr/bin`. but to be honest i am not sure where the line is on how much a role should care about previous state on a box.

other details:
- i've introduced `autorestic_architecture` as an override. i got a use case in which one of my machines returns `mips` for `uname -m` but is actually a `mipsle`, so i had to somehow circumvent that and make it obvious.
- i've listed the precompiled binary locations under dependencies, because that is what they are
- i removed the mode setting of the downloaded files to 0755 because i don't think this is necessary
- i dabbled with unarchive but that module can't rename extracted files, and does not play nicely with bzip2 so i reverted that to your approach. the versioned files however give us at least a chance to have idempotency with the `creates` directive.

hope this is clear enough