### PR TITLE
Breaking change: autorestic_config is now YAML, not a string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ autorestic_restic_install_directory:
 The directories to install the autorestic and restic binaries at.
 
 ```yaml
-autorestic_config: |-
+autorestic_config:
   version: 2
   locations:
     home:
@@ -53,7 +53,6 @@ autorestic_config: |-
       to: remote
       # Every Monday
       cron: "0 0 * * MON"
-
   backends:
     remote:
       type: b2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ autorestic_install_directory:
   path: /opt/autorestic/bin
 autorestic_restic_install_directory:
   path: /opt/restic/bin
-autorestic_config: |-
+autorestic_config:
   version: 2
   locations:
     home:
@@ -14,7 +14,6 @@ autorestic_config: |-
       to: remote
       # Every Monday
       cron: "0 0 * * MON"
-
   backends:
     remote:
       type: b2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,7 +47,7 @@
 
 - name: Create autorestic configuration file
   ansible.builtin.copy:
-    content: "{{ autorestic_config }}"
+    content: "{{ autorestic_config | to_yaml }}"
     dest: ~/.autorestic.yml
     mode: "0600"
 


### PR DESCRIPTION
This change allows Ansible or YAML linters to catch syntax errors in the
structure.

It also allows syntax highlighting to work.
